### PR TITLE
Add agent package using Effect AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ ideas with OpenAI's Codex. This repository is organized as a monorepo using
 
 The goal of this project is to keep experiments isolated in their own packages
 while still sharing a common toolchain and configuration. Currently the repo
-contains a single package named `core`, but new packages can be added as the
-experiments grow.
+contains two packages named `core` and `agent`, but new packages can be added as
+the experiments grow.
 
 ## Getting Started
 
@@ -57,5 +57,21 @@ Individual packages can be tested by running the script from their directory:
 ```bash
 cd packages/core
 npm test
+```
+
+## Using the Agent Package
+
+The `@codex/agent` workspace provides a small helper for requesting completions from OpenAI via Effect:
+
+```ts
+import { requestCompletion } from "@codex/agent"
+import * as Effect from "effect/Effect"
+
+const program = requestCompletion({
+  apiKey: process.env.OPENAI_API_KEY!,
+  prompt: "Hello, world!"
+})
+
+Effect.runPromise(program).then(console.log)
 ```
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@codex/agent",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "echo \"no tests\""
+  },
+  "dependencies": {
+    "@effect/ai": "^0.19.4",
+    "@effect/ai-openai": "^0.22.4"
+  }
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,0 +1,28 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as AiLanguageModel from "@effect/ai/AiLanguageModel";
+import * as AiResponse from "@effect/ai/AiResponse";
+import { AiError } from "@effect/ai/AiError";
+import * as OpenAiClient from "@effect/ai-openai/OpenAiClient";
+import * as OpenAiLanguageModel from "@effect/ai-openai/OpenAiLanguageModel";
+
+export interface CompletionRequest {
+  readonly apiKey: string;
+  readonly prompt: string;
+  readonly model?: string;
+}
+
+/**
+ * Request a completion from OpenAI using Effect's AI helpers.
+ */
+export const requestCompletion = (
+  options: CompletionRequest
+): Effect.Effect<AiResponse.AiResponse, AiError> =>
+  AiLanguageModel.generateText({ prompt: options.prompt }).pipe(
+    Effect.provideSomeLayer(
+      Layer.mergeAll(
+        OpenAiClient.layer({ apiKey: options.apiKey }),
+        OpenAiLanguageModel.layer({ model: options.model ?? "gpt-3.5-turbo" })
+      )
+    )
+  );

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add new `@codex/agent` workspace
- implement `requestCompletion` using `@effect/ai` with OpenAI
- document new package usage in README

## Testing
- `npm test` *(fails: lerna not found)*

------
https://chatgpt.com/codex/tasks/task_e_685706ebc9908323875903e3bf1b5ec5