### PR TITLE
Initialize memory bank docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,14 @@ const program = requestCompletion({
 Effect.runPromise(program).then(console.log)
 ```
 
+## Memory Bank
+
+Documentation for ongoing experiments, currently the roguelike deck‑builder, lives under [`memory-bank/`](memory-bank/). Core context files include:
+
+- [`projectbrief.md`](memory-bank/projectbrief.md) – high level goals and scope
+- [`productContext.md`](memory-bank/productContext.md) – why the game exists and desired experience
+- [`systemPatterns.md`](memory-bank/systemPatterns.md) – architecture and design patterns
+- [`techContext.md`](memory-bank/techContext.md) – chosen technologies
+- [`activeContext.md`](memory-bank/activeContext.md) – current milestones
+- [`progress.md`](memory-bank/progress.md) – status and next steps
+

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,0 +1,14 @@
+# Active Context
+
+The repository is configured as a TypeScript monorepo for Codex experimentation. Current focus is the minimal roguelike deck‑builder package:
+
+1. Establish the memory bank with core documents.
+2. Outline the MVP milestones.
+
+## MVP Milestones
+1. **CLI Skeleton** – basic command parsing and game loop.
+2. **Deck & Card System** – data structures and draw/play mechanics.
+3. **Encounter Logic** – procedural generation of enemies and rooms.
+4. **Basic Victory/Defeat Flow** – run through a short dungeon.
+
+Upcoming tasks involve creating a dedicated package for game logic and wiring it into the monorepo build.

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -1,0 +1,13 @@
+# Product Context
+
+This repo collects experiments that pair Codex with TypeScript tooling. The roguelike deck‑builder is one such experiment showcasing how **Effect‑TS** can structure a game loop while remaining easy to extend. Players progress through random encounters using a deck of cards. The first version runs in the command line yet remains flexible enough to support a web UI later.
+
+## Problems Solved
+- Demonstrates an Effect‑TS approach to stateful game logic
+- Provides a sandbox for experimenting with AI‑generated content
+- Allows incremental growth from CLI to potential web UI
+
+## User Goals
+- Quickly get a feel for deck‑building mechanics
+- Explore procedurally generated challenges
+- Contribute new cards or encounters with minimal friction

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,0 +1,12 @@
+# Progress
+
+- Monorepo initialized with Nx and Lerna
+- `core` and `agent` packages compile
+- Memory bank seeded with project brief and context files
+
+The repo will host multiple experiments, starting with the deck‑builder.
+
+## What's Next
+- Add a `game` package containing CLI and game logic
+- Flesh out deck and encounter systems
+- Create initial tests for core mechanics

--- a/memory-bank/projectbrief.md
+++ b/memory-bank/projectbrief.md
@@ -1,0 +1,11 @@
+# Project Brief
+
+This repository acts as a general playground for experimenting with OpenAI Codex in TypeScript. One key effort is a small **roguelike deck‑builder** game implemented with **Effect‑TS**. The monorepo is managed with **npm workspaces**, **Lerna**, and **Nx** so multiple packages (like `core` and `agent`) can evolve independently. The first game milestone is a playable command‑line prototype that could later become a web experience.
+
+## Scope
+- Basic deck‑builder mechanics (drawing, playing, discarding cards)
+- Procedural roguelike encounters
+- Command‑line interface to keep the MVP simple
+- Modular design so new cards and encounters can be added easily
+
+The project serves as a playground for Effect‑TS patterns and for experimenting with AI driven workflows.

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -1,0 +1,10 @@
+# System Patterns
+
+The repository follows a monorepo structure using npm workspaces, Lerna and Nx. Each package encapsulates specific functionality—for example `core` exposes shared utilities and `agent` wraps the OpenAI APIs. Experiments like the deck‑builder live in their own packages while reusing these utilities.
+
+Effect‑TS provides the runtime environment and effect system. The CLI interface will use Node streams. A future web interface can reuse the same core logic by exposing Effect‑TS programs through an HTTP server or client bundle.
+
+Key patterns:
+- **Layered effects**: dependencies such as RNG or persistence are provided via Effect layers.
+- **Pure logic** in core modules, separated from interfaces.
+- **Incremental build** using Nx for per‑package tasks.

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -1,0 +1,8 @@
+# Tech Context
+
+- **Language**: TypeScript targeting Node.js
+- **Framework**: Effect-TS for effect management and concurrency
+- **Tooling**: Nx and Lerna manage the monorepo, while ts-node/tsc handle builds
+- **Packages**: current workspaces include `core` (utility code) and `agent` (OpenAI helpers); new experiments add their own packages such as the upcoming `game`
+- **Interface**: MVP delivered as a CLI; potential web UI later
+- **Dependencies**: OpenAI client libraries via `@effect/ai` and `@effect/ai-openai`


### PR DESCRIPTION
## Summary
- seed memory bank with context for the roguelike deck-builder
- clarify that the repo hosts multiple Codex experiments
- document upcoming packages in tech and progress files
- link memory bank docs in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b8da36178832385ad3ed641ac57c9